### PR TITLE
feat: add basic Telegram bot skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Ein KI-gestützter LifeCoach-Bot mit Fokus auf persönliches Wachstum durch Mood
    ```bash
    cp .env.example .env
    ```
+   Beispielinhalt der `.env`:
+   ```env
+   TELEGRAM_TOKEN=dein-telegram-token
+   OPENAI_API_KEY=dein-openai-key
+   ```
 4. Bot starten:
    ```bash
    python bot/main.py

--- a/bot/handler.py
+++ b/bot/handler.py
@@ -1,18 +1,43 @@
-"""Bot handlers."""
+"""Telegram bot command handlers for the KI Life Coach bot."""
+
+from __future__ import annotations
+
 import logging
 from telegram import Update
 from telegram.ext import ContextTypes
 
+logger = logging.getLogger(__name__)
+
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Send a welcome message.
+    """Handle the ``/start`` command.
 
-    Args:
-        update: Incoming update.
-        context: Telegram context.
+    Sends a greeting and a short description of the project.
     """
     try:
-        await update.message.reply_text("Willkommen beim KI Life Coach Bot!")
-    except Exception as exc:
-        logging.exception("Handler error: %s", exc)
+        message = (
+            "Willkommen beim KI Life Coach Bot!\n\n"
+            "Ich unterstütze dich beim Mood-Tracking, GPT-Coaching "
+            "und Habit-Tracking."
+        )
+        await update.message.reply_text(message)
+    except Exception:
+        logger.exception("Failed to handle /start command")
+        raise
+
+
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle the ``/help`` command.
+
+    Provides a brief overview of available bot commands.
+    """
+    try:
+        message = (
+            "Verfügbare Befehle:\n"
+            "/start - Begrüßung und Projektüberblick\n"
+            "/help - Zeigt diese Hilfe an"
+        )
+        await update.message.reply_text(message)
+    except Exception:
+        logger.exception("Failed to handle /help command")
         raise

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,32 +1,75 @@
-"""Entry point for the Telegram bot."""
+"""Telegram bot starter script for the KI Life Coach project.
+
+This module loads the bot configuration, registers basic command handlers
+and starts the polling loop. The Telegram token is read from the environment
+or from a local ``.env`` file.
+"""
+
+from __future__ import annotations
+
 import logging
-from telegram.ext import Application
+import os
+from pathlib import Path
+from typing import Optional
+
+from telegram.ext import Application, CommandHandler, ContextTypes
+
+from handler import help_command, start
+
+# Configure logging once for the whole application
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
 
 
-async def start_bot(token: str) -> None:
-    """Start the Telegram bot.
+def _load_token() -> str:
+    """Return the Telegram bot token from env or ``.env``.
 
-    Args:
-        token: Telegram bot token.
+    The function first checks the ``TELEGRAM_TOKEN`` environment variable.
+    If it is not set, a ``.env`` file in the project root is parsed manually.
+
+    Raises:
+        RuntimeError: If no token can be found.
     """
-    try:
-        application = Application.builder().token(token).build()
-        await application.initialize()
-        await application.start()
-        await application.updater.start_polling()
-    except Exception as exc:
-        logging.exception("Failed to start bot: %s", exc)
-        raise
+
+    token: Optional[str] = os.getenv("TELEGRAM_TOKEN")
+    if token:
+        return token
+
+    env_path = Path(__file__).resolve().parents[1] / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            if line.startswith("TELEGRAM_TOKEN="):
+                token = line.split("=", 1)[1].strip()
+                if token:
+                    return token
+
+    raise RuntimeError("TELEGRAM_TOKEN is not configured")
+
+
+async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Log errors that occur within handler callbacks."""
+
+    logger.error("Update %s caused error %s", update, context.error)
 
 
 def main() -> None:
-    """Load configuration and launch the bot."""
-    logging.basicConfig(level=logging.INFO)
-    token = "YOUR_TELEGRAM_BOT_TOKEN"
-    import asyncio
+    """Start the Telegram bot."""
 
-    asyncio.run(start_bot(token))
+    token = _load_token()
+
+    # Build the application and register command handlers
+    application = Application.builder().token(token).build()
+    application.add_handler(CommandHandler("start", start))
+    application.add_handler(CommandHandler("help", help_command))
+    application.add_error_handler(error_handler)
+
+    logger.info("Bot is starting. Press Ctrl-C to stop.")
+    application.run_polling()
 
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- add Telegram bot entry script with environment-based token loading, logging and error handling
- implement `/start` and `/help` command handlers
- document `.env` setup and bot startup in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68926305331c833382772acbf6f0a510