### PR TITLE
Add mood tracking service and Telegram handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Ein KI-gestützter LifeCoach-Bot mit Fokus auf persönliches Wachstum durch Mood
    python bot/main.py
    ```
 
+## Mood-Tracking
+
+- `/mood <stimmung>` speichert deine tägliche Stimmung.
+- `/moodstats` zeigt eine Übersicht der letzten sieben Tage.
+- Die SQLite-Datenbank wird automatisch initialisiert und liegt unter `data/mood.db`.
+- Für manuelle Initialisierung: `from services.mood_service import init_db; init_db()`
+
 ## Hinweise für Entwickler
 - OpenAI-API: Verwende das offizielle `openai`-Package und setze den API-Key über die `.env`.
 - Telegram-API: `python-telegram-bot` nutzt asynchrone Handler; achte auf robuste Fehlerbehandlung und Logging.

--- a/bot/handler.py
+++ b/bot/handler.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import logging
 from telegram import Update
 from telegram.ext import ContextTypes
+from datetime import date, datetime, timedelta
+from collections import Counter
+import sqlite3
+
+from services import mood_service
 
 logger = logging.getLogger(__name__)
 
@@ -35,9 +40,88 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         message = (
             "Verfügbare Befehle:\n"
             "/start - Begrüßung und Projektüberblick\n"
-            "/help - Zeigt diese Hilfe an"
+            "/help - Zeigt diese Hilfe an\n"
+            "/mood <stimmung> - Speichert deine heutige Stimmung\n"
+            "/moodstats - Zeigt Statistiken der letzten 7 Tage"
         )
         await update.message.reply_text(message)
     except Exception:
         logger.exception("Failed to handle /help command")
         raise
+
+
+async def mood(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle the ``/mood`` command.
+
+    Records the user's mood and replies with the last entry and a weekly summary.
+    """
+    user_id = update.effective_user.id
+    if not context.args:
+        await update.message.reply_text(
+            "Bitte gib deine Stimmung an, z.B. /mood 😊 oder /mood gut"
+        )
+        return
+
+    mood_text = " ".join(context.args)
+    try:
+        previous = mood_service.get_last_mood(user_id)
+        mood_service.save_mood(user_id, mood_text, datetime.utcnow())
+
+        start = date.today() - timedelta(days=6)
+        week_entries = mood_service.get_moods(user_id, start, date.today())
+        chart = "".join(m for _, m in week_entries)
+        counts = Counter(m for _, m in week_entries)
+        stats = ", ".join(f"{m}: {c}" for m, c in counts.items())
+
+        response = [f"Stimmung gespeichert: {mood_text}"]
+        if previous:
+            prev_ts, prev_mood = previous
+            response.append(
+                f"Letzte Stimmung: {prev_mood} am {prev_ts:%d.%m.%Y}"
+            )
+        if chart:
+            response.append(f"Letzte Woche: {chart}\n{stats}")
+        await update.message.reply_text("\n".join(response))
+    except ValueError:
+        await update.message.reply_text(
+            "Du hast heute bereits eine Stimmung eingetragen."
+        )
+    except sqlite3.Error:
+        logger.exception("Database error while saving mood")
+        await update.message.reply_text(
+            "Beim Speichern deiner Stimmung ist ein Fehler aufgetreten."
+        )
+    except Exception:
+        logger.exception("Failed to handle /mood command")
+        await update.message.reply_text(
+            "Es ist ein unerwarteter Fehler aufgetreten."
+        )
+
+
+async def moodstats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle the ``/moodstats`` command.
+
+    Sends a summary of mood counts over the last seven days.
+    """
+    user_id = update.effective_user.id
+    try:
+        start = date.today() - timedelta(days=6)
+        week_entries = mood_service.get_moods(user_id, start, date.today())
+        if not week_entries:
+            await update.message.reply_text("Keine Einträge für die letzte Woche.")
+            return
+        counts = Counter(m for _, m in week_entries)
+        stats = "\n".join(f"{m}: {c}" for m, c in counts.items())
+        await update.message.reply_text(
+            f"Stimmungsübersicht der letzten 7 Tage:\n{stats}"
+        )
+    except sqlite3.Error:
+        logger.exception("Database error while fetching mood stats")
+        await update.message.reply_text(
+            "Beim Abrufen der Statistik ist ein Fehler aufgetreten."
+        )
+    except Exception:
+        logger.exception("Failed to handle /moodstats command")
+        await update.message.reply_text(
+            "Es ist ein unerwarteter Fehler aufgetreten."
+        )

--- a/bot/main.py
+++ b/bot/main.py
@@ -11,10 +11,14 @@ import logging
 import os
 from pathlib import Path
 from typing import Optional
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from telegram.ext import Application, CommandHandler, ContextTypes
 
-from handler import help_command, start
+from handler import help_command, start, mood, moodstats
+from services.mood_service import init_db
 
 # Configure logging once for the whole application
 logging.basicConfig(
@@ -60,10 +64,14 @@ def main() -> None:
 
     token = _load_token()
 
+    init_db()
+
     # Build the application and register command handlers
     application = Application.builder().token(token).build()
     application.add_handler(CommandHandler("start", start))
     application.add_handler(CommandHandler("help", help_command))
+    application.add_handler(CommandHandler("mood", mood))
+    application.add_handler(CommandHandler("moodstats", moodstats))
     application.add_error_handler(error_handler)
 
     logger.info("Bot is starting. Press Ctrl-C to stop.")

--- a/services/mood_service.py
+++ b/services/mood_service.py
@@ -1,0 +1,184 @@
+"""SQLite-backed mood tracking service."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import date, datetime
+from pathlib import Path
+from typing import List, Tuple
+
+logger = logging.getLogger(__name__)
+
+DB_PATH = Path(__file__).resolve().parents[1] / "data" / "mood.db"
+
+
+def init_db(db_path: Path | str = DB_PATH) -> None:
+    """Initialize the SQLite database for mood tracking.
+
+    Creates the database file and required table if they do not yet exist.
+
+    Args:
+        db_path: Path to the SQLite database file.
+    """
+    try:
+        path = Path(db_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS moods (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    mood TEXT NOT NULL,
+                    timestamp DATETIME NOT NULL
+                )
+                """
+            )
+    except sqlite3.Error:
+        logger.exception("Failed to initialize mood database")
+        raise
+
+
+def has_entry_for_date(
+    user_id: int, day: date, db_path: Path | str = DB_PATH
+) -> bool:
+    """Check whether a mood entry exists for a specific day.
+
+    Args:
+        user_id: Telegram user identifier.
+        day: Date for which to check.
+        db_path: Path to the SQLite database file.
+
+    Returns:
+        True if an entry for the user on ``day`` exists, otherwise False.
+    """
+    try:
+        with sqlite3.connect(db_path) as conn:
+            cur = conn.execute(
+                "SELECT 1 FROM moods WHERE user_id = ? AND DATE(timestamp) = ?",
+                (user_id, day.isoformat()),
+            )
+            return cur.fetchone() is not None
+    except sqlite3.Error:
+        logger.exception("Database error while checking existing mood")
+        raise
+
+
+def save_mood(
+    user_id: int,
+    mood: str,
+    timestamp: datetime | None = None,
+    db_path: Path | str = DB_PATH,
+) -> None:
+    """Store a mood entry for a user.
+
+    Args:
+        user_id: Telegram user identifier.
+        mood: Mood description or emoji.
+        timestamp: Time of the entry; defaults to current UTC time.
+        db_path: Path to the SQLite database file.
+
+    Raises:
+        ValueError: If a mood for the user has already been recorded today.
+    """
+    ts = timestamp or datetime.utcnow()
+    if has_entry_for_date(user_id, ts.date(), db_path=db_path):
+        raise ValueError("Mood already recorded for today")
+
+    try:
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "INSERT INTO moods (user_id, mood, timestamp) VALUES (?, ?, ?)",
+                (user_id, mood, ts.isoformat()),
+            )
+            conn.commit()
+    except sqlite3.Error:
+        logger.exception("Failed to save mood for user %s", user_id)
+        raise
+
+
+def get_moods(
+    user_id: int,
+    start_date: date,
+    end_date: date,
+    db_path: Path | str = DB_PATH,
+) -> List[Tuple[datetime, str]]:
+    """Return mood entries for a user within a date range.
+
+    Args:
+        user_id: Telegram user identifier.
+        start_date: Start date (inclusive).
+        end_date: End date (inclusive).
+        db_path: Path to the SQLite database file.
+
+    Returns:
+        List of tuples ``(timestamp, mood)`` ordered by timestamp ascending.
+    """
+    try:
+        with sqlite3.connect(db_path) as conn:
+            cur = conn.execute(
+                """
+                SELECT timestamp, mood FROM moods
+                WHERE user_id = ? AND DATE(timestamp) BETWEEN ? AND ?
+                ORDER BY timestamp ASC
+                """,
+                (user_id, start_date.isoformat(), end_date.isoformat()),
+            )
+            rows = cur.fetchall()
+            return [
+                (datetime.fromisoformat(ts), mood) for ts, mood in rows
+            ]
+    except sqlite3.Error:
+        logger.exception("Failed to fetch moods for user %s", user_id)
+        raise
+
+
+def get_last_mood(
+    user_id: int, db_path: Path | str = DB_PATH
+) -> Tuple[datetime, str] | None:
+    """Return the most recent mood entry for a user.
+
+    Args:
+        user_id: Telegram user identifier.
+        db_path: Path to the SQLite database file.
+
+    Returns:
+        Tuple of ``(timestamp, mood)`` or ``None`` if no entries exist.
+    """
+    try:
+        with sqlite3.connect(db_path) as conn:
+            cur = conn.execute(
+                "SELECT timestamp, mood FROM moods WHERE user_id = ? "
+                "ORDER BY timestamp DESC LIMIT 1",
+                (user_id,),
+            )
+            row = cur.fetchone()
+            return (datetime.fromisoformat(row[0]), row[1]) if row else None
+    except sqlite3.Error:
+        logger.exception("Failed to fetch last mood for user %s", user_id)
+        raise
+
+
+def export_moods_to_csv(
+    user_id: int, file_path: Path | str, db_path: Path | str = DB_PATH
+) -> None:
+    """Export moods for a user to a CSV file.
+
+    Args:
+        user_id: Telegram user identifier.
+        file_path: Destination path for the CSV file.
+        db_path: Path to the SQLite database file.
+    """
+    import csv
+
+    try:
+        moods = get_moods(user_id, date.min, date.max, db_path=db_path)
+        with open(file_path, "w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(["timestamp", "mood"])
+            for ts, mood in moods:
+                writer.writerow([ts.isoformat(), mood])
+    except Exception:
+        logger.exception("Failed to export moods to CSV for user %s", user_id)
+        raise

--- a/tests/test_mood_service.py
+++ b/tests/test_mood_service.py
@@ -1,0 +1,31 @@
+"""Tests for the mood tracking service."""
+
+from datetime import date, datetime
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from services import mood_service
+
+
+def test_save_and_get_mood(tmp_path) -> None:
+    """Mood entries can be saved and retrieved."""
+    db = tmp_path / "mood.db"
+    mood_service.init_db(db)
+    now = datetime(2024, 1, 1, 12, 0)
+    mood_service.save_mood(1, "😊", now, db)
+    moods = mood_service.get_moods(1, date(2024, 1, 1), date(2024, 1, 1), db)
+    assert moods[0][1] == "😊"
+
+
+def test_duplicate_mood_raises(tmp_path) -> None:
+    """Saving two moods on the same day raises an error."""
+    db = tmp_path / "mood.db"
+    mood_service.init_db(db)
+    now = datetime(2024, 1, 1, 8, 0)
+    mood_service.save_mood(1, "gut", now, db)
+    with pytest.raises(ValueError):
+        mood_service.save_mood(1, "schlecht", now, db)


### PR DESCRIPTION
## Summary
- implement SQLite-based `mood_service` with CRUD helpers and export function
- add `/mood` and `/moodstats` Telegram handlers with weekly summaries
- document mood tracking usage and init in README and initialize DB at startup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892dd565db08333ac05225c613c7a04